### PR TITLE
Adds HTMLUrlFinder object to find and extract urls on a visited page

### DIFF
--- a/lib/crwlr.js
+++ b/lib/crwlr.js
@@ -4,6 +4,9 @@ const urlParser = require('url');
 const EventEmitter = require('events');
 const visitor = require('./visitor');
 
+// internal plugins
+const HtmlUrlFinder = require('./page-parser/html-url-finder');
+
 function Crwlr(startUrl) {
     const queue = [];
     const events = new EventEmitter();
@@ -73,6 +76,9 @@ function Crwlr(startUrl) {
     var crawlComplete = () => {
         console.log('Crawl complete');
     };
+
+    // register internal plugins
+    this.use(new HtmlUrlFinder());
 
     this.queueUrl(startUrl);
 };

--- a/lib/page-parser/html-url-finder.js
+++ b/lib/page-parser/html-url-finder.js
@@ -1,0 +1,54 @@
+'use strict';
+
+const cheerio = require('cheerio');
+const _ = require('lodash');
+
+module.exports = function HtmlUrlFinder() {
+    var baseUrl;
+    var crwlr;
+
+    this.register = ($crwlr) => {
+        baseUrl = $crwlr.getBaseUrl();
+        crwlr = $crwlr;
+
+        crwlr.on('crwlr.visitor.post-visit', findUrls);
+    };
+
+    function findUrls(page) {
+        var $ = cheerio.load(page.getRawBody());
+        var anchorElements = $(`a[href]`);
+
+        console.log('Found %d urls in %s', anchorElements.length, page.getPageUrl());
+
+        anchorElements.each(function() {
+            var childUrl = $(this).attr('href');
+
+            if (!isAllowedUrl(childUrl)) {
+                return;
+            }
+
+            var canonisedUrl = canoniseUrl(childUrl);
+            
+            crwlr.queueUrl(canonisedUrl);
+        });
+    }
+
+    function canoniseUrl(url) {
+        // rebuild urls like ../../../../path/to/page.html to path/to/page.html
+        // and prepend baseUrl if url is relative
+        if (!url.match(`^${baseUrl}`)) {
+            url = baseUrl + '/' + url.replace(/(\.\.\/)+/, '');
+        }
+
+        return _.trimEnd(url, '/');
+    }
+
+    function isAllowedUrl(url) {
+        if (url.match(`^${baseUrl}`)) {
+            return true;
+        }
+
+        return url.match(/^[^http]/) !== null
+            && url.match(/^[^//]/) !== null;
+    }
+};


### PR DESCRIPTION
These 'allowed' urls are feed back into the internal url/job queue managed by crwlr
Allowed urls are urls that point to the same baseUrl.
For example, given a domain example.com:
- example.com/foo is allowed
- sub.example.com/foo is not allowed
- otherexample.com/bar is not allowed and will not be visited

The HtmlUrlFinder is created as a plugin and subscribes to 'crwlr.visitor.post-visit' event published when a page is visited.