### PR TITLE
Adds SitemapBuilder to build a simple JSON map info of crawled website

### DIFF
--- a/index.js
+++ b/index.js
@@ -8,4 +8,11 @@ if (!startUrl) {
 
 const Crwlr = require('./lib/crwlr');
 const crwlr = new Crwlr(startUrl);
+const fs = require('fs');
+
+crwlr.on('crwlr.crawl.complete', function(sitemap) {
+    var fileName = __dirname + '/sitemap.json';
+    console.log('Writing site map to', fileName);
+    fs.writeFileSync(fileName, JSON.stringify(sitemap, null, "\t"));
+});
 crwlr.crawl();

--- a/lib/crwlr.js
+++ b/lib/crwlr.js
@@ -3,6 +3,7 @@
 const urlParser = require('url');
 const EventEmitter = require('events');
 const visitor = require('./visitor');
+const SitemapBuilder = require('./sitemap-builder');
 
 // internal plugins
 const HtmlUrlFinder = require('./page-parser/html-url-finder');
@@ -10,6 +11,7 @@ const HtmlUrlFinder = require('./page-parser/html-url-finder');
 function Crwlr(startUrl) {
     const queue = [];
     const events = new EventEmitter();
+    const sitemapBuilder = new SitemapBuilder;
     const parsedUrl = urlParser.parse(startUrl);
     const baseUrl = `${parsedUrl.protocol}//${parsedUrl.hostname}`;
     const eventsMap = {
@@ -75,10 +77,11 @@ function Crwlr(startUrl) {
 
     var crawlComplete = () => {
         console.log('Crawl complete');
+        events.emit(eventsMap['finish'], sitemapBuilder.get());
     };
 
     // register internal plugins
-    this.use(new HtmlUrlFinder());
+    this.use(new HtmlUrlFinder(sitemapBuilder));
 
     this.queueUrl(startUrl);
 };

--- a/lib/page-parser/html-url-finder.js
+++ b/lib/page-parser/html-url-finder.js
@@ -3,7 +3,7 @@
 const cheerio = require('cheerio');
 const _ = require('lodash');
 
-module.exports = function HtmlUrlFinder() {
+module.exports = function HtmlUrlFinder(sitemapBuilder) {
     var baseUrl;
     var crwlr;
 
@@ -30,6 +30,7 @@ module.exports = function HtmlUrlFinder() {
             var canonisedUrl = canoniseUrl(childUrl);
             
             crwlr.queueUrl(canonisedUrl);
+            sitemapBuilder.addPageUrl(page.getPageUrl(), canonisedUrl);
         });
     }
 
@@ -37,6 +38,7 @@ module.exports = function HtmlUrlFinder() {
         // rebuild urls like ../../../../path/to/page.html to path/to/page.html
         // and prepend baseUrl if url is relative
         if (!url.match(`^${baseUrl}`)) {
+            url = _.trimStart(url, '/');
             url = baseUrl + '/' + url.replace(/(\.\.\/)+/, '');
         }
 
@@ -49,6 +51,6 @@ module.exports = function HtmlUrlFinder() {
         }
 
         return url.match(/^[^http]/) !== null
-            && url.match(/^[^//]/) !== null;
+            && url.match(/^\/\//) === null;
     }
 };

--- a/lib/sitemap-builder.js
+++ b/lib/sitemap-builder.js
@@ -1,0 +1,48 @@
+'use strict';
+
+function SitemapBuilder() {
+    const sitemap = {};
+
+    this.addPageUrl = function(parentUrl, url) {
+        addPage(parentUrl);
+        addUrl('urls', parentUrl, url);
+    };
+
+    this.addImageUrl = function(parentUrl, url) {
+        addPage(parentUrl);
+        addUrl('images', parentUrl, url);
+    };
+
+    this.addCssUrl = function(parentUrl, url) {
+        addPage(parentUrl);
+        addUrl('css', parentUrl, url);
+    };
+
+    this.addJsUrl = function(parentUrl, url) {
+        addPage(parentUrl);
+        addUrl('js', parentUrl, url);
+    };
+
+    this.get = function() {
+        return sitemap;
+    }
+
+    function addUrl(key, parentUrl, url) {
+        if (sitemap[parentUrl][key].indexOf(url) == -1) {
+            sitemap[parentUrl][key].push(url);
+        }
+    }
+
+    function addPage(parentUrl) {
+        if (!(parentUrl in sitemap)) {
+            sitemap[parentUrl] = {
+                urls: [],
+                images: [],
+                css: [],
+                js: []
+            };
+        }
+    }
+};
+
+module.exports = SitemapBuilder;


### PR DESCRIPTION
The HtmlUrlFinder is initialised with the sitemap builder and adds page data as it finds and extract urls from visited pages

The sitemap builder is responsible to organising this page data into hierarchies by maintain an in-memory map, which is persisted in ./index.js to a sitemap.json file at the end of the crawling session