### PR TITLE
Adds image and js url finder plugins

### DIFF
--- a/lib/crwlr.js
+++ b/lib/crwlr.js
@@ -8,6 +8,8 @@ const SitemapBuilder = require('./sitemap-builder');
 // internal plugins
 const HtmlUrlFinder = require('./page-parser/html-url-finder');
 const CssUrlFinder = require('./page-parser/css-url-finder');
+const ImageUrlFinder = require('./page-parser/css-url-finder');
+const JsUrlFinder = require('./page-parser/css-url-finder');
 
 function Crwlr(startUrl) {
     const queue = [];
@@ -84,6 +86,8 @@ function Crwlr(startUrl) {
     // register internal plugins
     this.use(new HtmlUrlFinder(sitemapBuilder));
     this.use(new CssUrlFinder(sitemapBuilder));
+    this.use(new ImageUrlFinder(sitemapBuilder));
+    this.use(new JsUrlFinder(sitemapBuilder));
 
     this.queueUrl(startUrl);
 };

--- a/lib/page-parser/image-url-finder.js
+++ b/lib/page-parser/image-url-finder.js
@@ -1,0 +1,32 @@
+'use strict';
+
+const cheerio = require('cheerio');
+const _ = require('lodash');
+
+module.exports = function ImageUrlFinder(sitemapBuilder) {
+    var baseUrl;
+    var crwlr;
+
+    this.register = ($crwlr) => {
+        baseUrl = $crwlr.getBaseUrl();
+        crwlr = $crwlr;
+
+        crwlr.on('crwlr.visitor.post-visit', findImageUrls);
+    };
+
+    function findImageUrls(page) {
+        var $ = cheerio.load(page.getRawBody());
+
+        $(`*[style^='background']`).each(function() {
+            var imageSrc = $(this).attr('style').replace(/.*\s?url\([\'\"]?/, '').replace(/[\'\"]?\).*/, '');
+            console.log('Found image url', imageSrc);
+            sitemapBuilder.addImageUrl(page.getPageUrl(), imageSrc);
+        });
+
+        $(`img[src]`).each(function() {
+            var imageSrc = $(this).attr('src');
+            console.log('Found image url', imageSrc);
+            sitemapBuilder.addImageUrl(page.getPageUrl(), imageSrc);
+        });
+    }
+};

--- a/lib/page-parser/javascript-url-finder.js
+++ b/lib/page-parser/javascript-url-finder.js
@@ -1,0 +1,26 @@
+'use strict';
+
+const cheerio = require('cheerio');
+const _ = require('lodash');
+
+module.exports = function JsUrlFinder(sitemapBuilder) {
+    var baseUrl;
+    var crwlr;
+
+    this.register = ($crwlr) => {
+        baseUrl = $crwlr.getBaseUrl();
+        crwlr = $crwlr;
+
+        crwlr.on('crwlr.visitor.post-visit', findUrls);
+    };
+
+    function findUrls(page) {
+        var $ = cheerio.load(page.getRawBody());
+
+        $('script[type="text/javascript"][src]').each(function() {
+            var url = $(this).attr('src');
+            console.log('Found js url', url);
+            sitemapBuilder.addJsUrl(page.getPageUrl(), url);
+        });
+    }
+};

--- a/tests/lib/unit/page-parser/image-url-finder-test.js
+++ b/tests/lib/unit/page-parser/image-url-finder-test.js
@@ -1,0 +1,60 @@
+'use strict';
+
+const sinon = require('sinon');
+const assert = require('chai').assert;
+const EventEmitter = require('events');
+const Page = require('../../../../lib/page');
+const ImageUrlFinder = require('../../../../lib/page-parser/image-url-finder');
+
+describe('ImageUrlFinder', function() {
+    let imageUrlFinder;
+    let mockSitemapBuilder;
+
+    before(() => {
+        mockSitemapBuilder = {
+            addImageUrl: sinon.stub()
+        };
+        imageUrlFinder = new ImageUrlFinder(mockSitemapBuilder);
+    });
+
+    it('extracts urls from html document', function () {
+        EventEmitter.prototype.getBaseUrl = function() {
+            return 'http://example.com';
+        };
+
+        EventEmitter.prototype.queueUrl = function() {};
+
+        var events = new EventEmitter();
+        var pageUrl = 'http://example.com/foo';
+        var rawBody = `<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+    <title>title</title>
+    <link rel="stylesheet" href="style.css">
+    <link rel="stylesheet" href="/style-1.css">
+    <link rel="stylesheet" href="//example.com/style-2.css">
+    <script type="text/javascript" src="script.js"></script>
+    <script type="text/javascript" src="http://example.com/script1.js"></script>
+    <script type="text/javascript" src="http://statics.cdn.com/script2.js"></script>
+  </head>
+  <body>
+    <a href="/bar">Bar</a>
+    <a href="http://example.com/baz">Baz</a>
+    <a href="http://google.com">Google</a>
+    <a href="http://facebook.com">Facebook</a>
+    <img src="http://facebook.com/images/foo.img" />
+  </body>
+</html>`;
+
+        imageUrlFinder.register(events);
+
+        events.emit('crwlr.visitor.post-visit', new Page(pageUrl, rawBody));
+
+        sinon.assert.callCount(mockSitemapBuilder.addImageUrl, 1);
+        assert.deepEqual(
+            mockSitemapBuilder.addImageUrl.getCall(0).args,
+            ['http://example.com/foo', 'http://facebook.com/images/foo.img']
+        );
+    });
+});

--- a/tests/lib/unit/page-parser/js-url-finder-test.js
+++ b/tests/lib/unit/page-parser/js-url-finder-test.js
@@ -1,0 +1,67 @@
+'use strict';
+
+const sinon = require('sinon');
+const assert = require('chai').assert;
+const EventEmitter = require('events');
+const Page = require('../../../../lib/page');
+const JsUrlFinder = require('../../../../lib/page-parser/javascript-url-finder');
+
+describe('JsUrlFinder', function() {
+    let jsUrlFinder;
+    let mockSitemapBuilder;
+
+    before(() => {
+        mockSitemapBuilder = {
+            addJsUrl: sinon.stub()
+        };
+        jsUrlFinder = new JsUrlFinder(mockSitemapBuilder);
+    });
+
+    it('extracts urls from html document', function () {
+        EventEmitter.prototype.getBaseUrl = function() {
+            return 'http://example.com';
+        };
+
+        EventEmitter.prototype.queueUrl = function() {};
+
+        var events = new EventEmitter();
+        var pageUrl = 'http://example.com/foo';
+        var rawBody = `<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+    <title>title</title>
+    <link rel="stylesheet" href="style.css">
+    <link rel="stylesheet" href="/style-1.css">
+    <link rel="stylesheet" href="//example.com/style-2.css">
+    <script type="text/javascript" src="script.js"></script>
+    <script type="text/javascript" src="http://example.com/script1.js"></script>
+    <script type="text/javascript" src="http://statics.cdn.com/script2.js"></script>
+  </head>
+  <body>
+    <a href="/bar">Bar</a>
+    <a href="http://example.com/baz">Baz</a>
+    <a href="http://google.com">Google</a>
+    <a href="http://facebook.com">Facebook</a>
+  </body>
+</html>`;
+
+        jsUrlFinder.register(events);
+
+        events.emit('crwlr.visitor.post-visit', new Page(pageUrl, rawBody));
+
+        sinon.assert.callCount(mockSitemapBuilder.addJsUrl, 3);
+        assert.deepEqual(
+            mockSitemapBuilder.addJsUrl.getCall(0).args,
+            ['http://example.com/foo', 'script.js']
+        );
+        assert.deepEqual(
+            mockSitemapBuilder.addJsUrl.getCall(1).args,
+            ['http://example.com/foo', 'http://example.com/script1.js']
+        );
+        assert.deepEqual(
+            mockSitemapBuilder.addJsUrl.getCall(2).args,
+            ['http://example.com/foo', 'http://statics.cdn.com/script2.js']
+        );
+    });
+});


### PR DESCRIPTION
Adds crwlr url finder plugins: javascript and images url finders

JS url finder looks for `script` tags with the attribute `type="text/javascript"`.
Image url finder looks for `img` DOM elements. It is also able to find background images on elements where syntax is `<* style="background: url(path/to/image.ext)`.