### PR TITLE
Updates HTMLUrlFinder to add all urls it finds on a page to  the SitemapManager

### DIFF
--- a/lib/page-parser/html-url-finder.js
+++ b/lib/page-parser/html-url-finder.js
@@ -23,15 +23,22 @@ module.exports = function HtmlUrlFinder(sitemapBuilder) {
         anchorElements.each(function() {
             var childUrl = $(this).attr('href');
 
-            if (!isAllowedUrl(childUrl)) {
-                return;
-            }
+            sitemapBuilder.addPageUrl(page.getPageUrl(), childUrl);
 
-            var canonisedUrl = canoniseUrl(childUrl);
-            
-            crwlr.queueUrl(canonisedUrl);
-            sitemapBuilder.addPageUrl(page.getPageUrl(), canonisedUrl);
+            if (canVisitUrl(childUrl)) {
+                var canonisedUrl = canoniseUrl(childUrl);
+                crwlr.queueUrl(canonisedUrl);
+            }
         });
+    }
+
+    function canVisitUrl(url) {
+        if (url.match(`^${baseUrl}`)) {
+            return true;
+        }
+
+        return url.match(/^[^http]/) !== null
+            && url.match(/^\/\//) === null;
     }
 
     function canoniseUrl(url) {
@@ -43,14 +50,5 @@ module.exports = function HtmlUrlFinder(sitemapBuilder) {
         }
 
         return _.trimEnd(url, '/');
-    }
-
-    function isAllowedUrl(url) {
-        if (url.match(`^${baseUrl}`)) {
-            return true;
-        }
-
-        return url.match(/^[^http]/) !== null
-            && url.match(/^\/\//) === null;
     }
 };

--- a/tests/lib/unit/page-parser/html-url-finder-test.js
+++ b/tests/lib/unit/page-parser/html-url-finder-test.js
@@ -23,7 +23,7 @@ describe('HtmlUrlFinder', function() {
             return 'http://example.com';
         };
 
-        EventEmitter.prototype.queueUrl = function() {};
+        EventEmitter.prototype.queueUrl = sinon.stub();
 
         var events = new EventEmitter();
         var pageUrl = 'http://example.com/foo';
@@ -47,14 +47,14 @@ describe('HtmlUrlFinder', function() {
 
         events.emit('crwlr.visitor.post-visit', new Page(pageUrl, rawBody));
 
-        sinon.assert.callCount(mockSitemapBuilder.addPageUrl, 2);
-        assert.deepEqual(
-            mockSitemapBuilder.addPageUrl.getCall(0).args,
-            ['http://example.com/foo', 'http://example.com/bar']
-        );
-        assert.deepEqual(
-            mockSitemapBuilder.addPageUrl.getCall(1).args,
-            ['http://example.com/foo', 'http://example.com/baz']
-        );
+        sinon.assert.callCount(mockSitemapBuilder.addPageUrl, 4);
+        assert.deepEqual(mockSitemapBuilder.addPageUrl.getCall(0).args, [pageUrl, '/bar']);
+        assert.deepEqual(mockSitemapBuilder.addPageUrl.getCall(1).args, [pageUrl, 'http://example.com/baz']);
+        assert.deepEqual(mockSitemapBuilder.addPageUrl.getCall(2).args, [pageUrl, 'http://google.com']);
+        assert.deepEqual(mockSitemapBuilder.addPageUrl.getCall(3).args, [pageUrl, 'http://facebook.com']);
+
+        sinon.assert.callCount(events.queueUrl, 2);
+        assert.deepEqual(events.queueUrl.getCall(0).args, ['http://example.com/bar']);
+        assert.deepEqual(events.queueUrl.getCall(1).args, ['http://example.com/baz']);
     });
 });


### PR DESCRIPTION
It is useful to see all urls found on each page, even though external urls will not be visited.